### PR TITLE
chore: hide surface install guide

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -21,7 +21,6 @@ const sidebars: SidebarsConfig = {
       items: [
         "guides/system-requirements",
         "guides/install-guide",
-        "guides/surface-install-guide",
         "guides/installation-troubleshoot",
         "guides/alternate-install-guide",
       ],


### PR DESCRIPTION
Hide the surface guide because it contains an outdated guide how to install Aurora (using Ventoy) + were not supporting HWE soon. Feedback on this please @renner0e @inffy @ledif @RealVishy. 