### PR TITLE
ci: add Chandeleer to typos

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -18,3 +18,4 @@ jobs:
         uses: crate-ci/typos@d7e6241ebf2f59df88a9e53567d2fdc5141c2fd1 # version 1.0.4
         with:
           files: ./README.md ./docs
+          config: ./typos.toml

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+Chandeleer = "Chandeleer"


### PR DESCRIPTION
this should get rid of these
<img width="489" height="144" alt="image" src="https://github.com/user-attachments/assets/afb0057a-06e7-4474-b069-2f006554158c" />
