### PR TITLE
chore: remove steam appimage and bazzite-arch

### DIFF
--- a/docs/guides/gaming.md
+++ b/docs/guides/gaming.md
@@ -17,7 +17,7 @@ Before starting with gaming on Aurora, ensure you have:
 
 ## Overview
 
-Despite not being primarily a gaming-focused image, you can still run video games at _nearly_ the same performance as nearly any other Linux operating system out there. Aurora supports gaming through various methods including Flatpak Steam, Lutris, and containerized gaming environments. This guide will help you set up and choose the best gaming solution for your needs. However, [Bazzite](https://bazzite.gg) is the better choice if your gaming needs rank higher over productivity, development, or general computing usage.
+Despite not being primarily a gaming-focused image, you can still run video games at _nearly_ the same performance as nearly any other Linux operating system out there. Aurora supports gaming through various methods including Flatpak Steam, Lutris, and containerized gaming environments. This guide will help you set up a casual gaming environment through flatpaks.
 
 ## Quick Install Gaming Tools
 
@@ -35,10 +35,6 @@ This command will install:
 - [ProtonUp-Qt](https://davidotek.github.io/protonup-qt/)
 - Essential Vulkan runtimes and tools ([Gamescope](https://github.com/ValveSoftware/gamescope), [MangoHud](https://github.com/flightlessmango/MangoHud), [OBS VKCapture](https://github.com/nowrep/obs-vkcapture))
 
-## Gaming Options
-
-### Flatpak Steam
-
 Steam through Flatpak provides several advantages:
 
 1. Sandboxed environment for improved security with granular and adjustable permissions
@@ -48,31 +44,9 @@ Steam through Flatpak provides several advantages:
 
 View the [Steam Flatpak Github Wiki](https://github.com/flathub/com.valvesoftware.Steam/wiki) for a short list of workarounds that may need to be done in comparison to other package formats.
 
-### Steam Appimage
-
-For those wanting a dedicated gaming environment without switching distributions but also didn't want to use distrobox Steam Appimage can be a solution.
-
-It provides almost same benefit with Bazzite-Arch container but without need to mess around with command line.
-
-How to install Steam Appimage:
-
-1.  First you need to download Steam Appimage from [here](https://github.com/ivan-hc/Steam-appimage/releases).
-2.  Then install [GearLever](https://flathub.org/apps/it.mijorus.gearlever) from Flathub.
-3.  After that right click AppImage file and select open with GearLever, if you seen this menu select Unlock then select
-    Move to The App Menu.
-    ![GearLever](/img/steam/gearlever1.png)
-    ![GearLever](/img/steam/gearlever2.png)
-4.  Now Steam Appimage is ready to game!
-
-If gaming is your primary focus, consider switching to Bazzite as your main operating system since it offers:
-
-1. Pre-configured gaming optimizations
-2. Latest gaming-related drivers and tools
-3. Built-in support for multiple gaming platforms
-4. Regular updates focused on gaming performance
-5. Active gaming-focused community
-
 ## Switch to Bazzite from Aurora
+
+[Bazzite](https://bazzite.gg) is the better choice if your gaming needs rank higher over productivity, development, or general computing usage.
 
 **Note**: Make sure you are not rebasing to a GNOME image of Bazzite as rebasing to a different Desktop Environment is not supported.
 
@@ -86,8 +60,7 @@ sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/bazzite:stable
 ## Recommendations
 
 1. **Casual Gaming**: Use Flatpak Steam and gaming tools installed through `ujust install-gaming-flatpaks`
-2. **Mixed Usage**: Consider the Bazzite-Arch container for a dedicated gaming environment while keeping Aurora as your daily driver
-3. **Gaming Focus**: Switch to full Bazzite installation for the best gaming experience
+2. **Gaming Focus**: Switch to full Bazzite installation for the best gaming experience
 
 ## Tools and Performance Monitoring
 
@@ -145,6 +118,5 @@ This guide is regularly updated as Aurora evolves. For the most recent informati
 
 ## Additional Notes
 
-- The [bazzite-arch container](https://github.com/ublue-os/bazzite-arch) comes with `paru` pre-installed and modified `xdg-utils` for seamless integration with your host system
 - Flatpak Steam may have slight performance overhead due to sandboxing, but this is usually negligible
 - When using Flatpak Steam, be aware that games are run in a sandboxed environment for improved security


### PR DESCRIPTION
Removes Steam AppImage from the guide and removes some mentions of the bazzite arch container because its barely maintained anymore.