### PR TITLE
fix: ramalama mentioned as included

### DIFF
--- a/docs/dx/aurora-dx-intro.md
+++ b/docs/dx/aurora-dx-intro.md
@@ -129,9 +129,9 @@ DevPod also has support for JetBrains:
 
 If you feel there's a tool that should be included by default, send a PR [to this file](https://github.com/ublue-os/packages/blob/main/packages/aurora/schemas/usr/share/ublue-os/homebrew/kubernetes.Brewfile). But let's not overdo it.
 
-## Ramalama
+## Ramalama and other AI tools
 
-[Ramalama](https://github.com/containers/ramalama) is included for local management and serving of AI models. Check the [AI documentation](/guides/local-ai) for more information.
+[Ramalama](https://github.com/containers/ramalama) can be installed via `ujust install-ai-tools` for local management and serving of AI models. Check the [AI documentation](/guides/local-ai) for more information.
 
 ## Virtualization and Container Runtimes
 

--- a/docs/guides/local-ai.md
+++ b/docs/guides/local-ai.md
@@ -9,7 +9,7 @@ _Use the robots to your advantage!_
 
 ## Ramalama
 
-[Ramalama](https://github.com/containers/ramalama) is a tool which is included on the developer experience images that makes managing and working with AI models on your local machine super easy and smoooth.
+[Ramalama](https://github.com/containers/ramalama) is a tool which can be installed with the `ujust install-ai-tools` recipe, that makes managing and working with AI models on your local machine super easy and smoooth.
 
 It can pull models from Huggingface, Ollama and other providers without extra configuration or hassle. By default it is pulling its models from the Ollama Model Registry, which you can find here: [Ollama Model Registry](https://ollama.com/search).
 


### PR DESCRIPTION
Ramalama was removed from Aurora in https://github.com/ublue-os/aurora/pull/839
But the docs were not updated accordingly.

This PR updates the docs to mention Ramalama as installable via the new `ujust` recipe, instead of being included already.