### PR TITLE
docs: correct gramar of Introduction page

### DIFF
--- a/docs/guides/intro.md
+++ b/docs/guides/intro.md
@@ -65,7 +65,7 @@ System updates are image-based and automatic. Applications are logically separat
 
 ## How is this different from a traditional Linux Desktop?
 
-- Aurora takes a [greenfield approach](https://en.wikipedia.org/wiki/Greenfield_project) to Linux applications by defaulting to Flathub and `brew` by default
+- Aurora takes a [greenfield approach](https://en.wikipedia.org/wiki/Greenfield_project) to Linux applications by defaulting to Flathub and `brew`.
 - Aurora recommends using containerized tools - it focuses on [Devcontainers](https://containers.dev) for declarative containerized development. You can use Podman or Docker to run and bootstrap your containers.
 - Aurora _tries_ to remove the need for the user to use `rpm-ostree` or `bootc` directly
 - Aurora focuses on automation of OS services and upgrades instead of user interaction. Upgrades are automatic and silent, so you never have to think about it again.


### PR DESCRIPTION
Fixed an sentence with a redundant statement of "defaulting to ... by default."
in the current main on of the differences between Aurora and a traditional Linux Desktop it reads

* Aurora takes a [greenfield approach](https://en.wikipedia.org/wiki/Greenfield_project) to Linux applications by defaulting to Flathub and brew by default

this is incorrect as it double specifies default "defaults to ... by default" this pull request fixes it by removing the "by defaults" portion of the sentence