### PR TITLE
Fixed typo in alternate install guide

### DIFF
--- a/docs/guides/alternate-install-guide.md
+++ b/docs/guides/alternate-install-guide.md
@@ -37,7 +37,7 @@ ujust install-system-flatpaks
 
 # Rebasing from an existing Fedora Kinoite Installation
 
-Fist you might want to permanently save your current deployment:
+First you might want to permanently save your current deployment:
 
 ```
 sudo ostree admin pin 0


### PR DESCRIPTION
Changed the word "Fist" to "First" in the "Rebasing from an existing Fedora Kinoite Installation" section of the alternative install guide, fixing a typo.