### PR TITLE
fix: pdf generation error with moving down to node v20

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 24
+          node-version: 20
 
       - name: Install Prince
         run: |
@@ -25,7 +25,7 @@ jobs:
           cd prince-16.2-linux-generic-x86_64
           yes "" | sudo ./install.sh
       - name: Build PDF
-        run: npx --yes --package github:signcl/docusaurus-prince-pdf#33905dfa2015e046655d8f970928e5eaa054be65 docusaurus-prince-pdf --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf
+        run: npx docusaurus-prince-pdf@1.2.1 --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf
       - name: Upload results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -25,7 +25,7 @@ jobs:
           cd prince-16.2-linux-generic-x86_64
           yes "" | sudo ./install.sh
       - name: Build PDF
-        run: npx docusaurus-prince-pdf --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf
+        run: npx docusaurus-prince-pdf@1.2.2 --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf
       - name: Upload results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -25,7 +25,7 @@ jobs:
           cd prince-16.2-linux-generic-x86_64
           yes "" | sudo ./install.sh
       - name: Build PDF
-        run: npx docusaurus-prince-pdf@1.2.2 --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf
+        run: npx --yes --package github:signcl/docusaurus-prince-pdf#33905dfa2015e046655d8f970928e5eaa054be65 docusaurus-prince-pdf --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf
       - name: Upload results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -2,7 +2,8 @@ name: Generate Docs PDF
 on:
   push:
     branches:
-      - main
+      - "**"
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -13,18 +14,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      
-
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
 
       - name: Install Prince
         run: |
-          curl https://www.princexml.com/download/prince-16.2-linux-generic-x86_64.tar.gz
+          curl -LO https://www.princexml.com/download/prince-16.2-linux-generic-x86_64.tar.gz
           tar zxf prince-16.2-linux-generic-x86_64.tar.gz
-          cd prince-16.2-linux-generic-x86_64.tar.gz
+          cd prince-16.2-linux-generic-x86_64
           yes "" | sudo ./install.sh
       - name: Build PDF
         run: npx docusaurus-prince-pdf --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf
       - name: Upload results
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: aurora
@@ -33,7 +36,7 @@ jobs:
           if-no-files-found: error
           overwrite: true
       - name: Upload Release Artifact
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -13,11 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      
+
+
       - name: Install Prince
         run: |
-          curl https://www.princexml.com/download/prince-15.4.1-linux-generic-x86_64.tar.gz -O
-          tar zxf prince-15.4.1-linux-generic-x86_64.tar.gz
-          cd prince-15.4.1-linux-generic-x86_64
+          curl https://www.princexml.com/download/prince-16.2-linux-generic-x86_64.tar.gz
+          tar zxf prince-16.2-linux-generic-x86_64.tar.gz
+          cd prince-16.2-linux-generic-x86_64.tar.gz
           yes "" | sudo ./install.sh
       - name: Build PDF
         run: npx docusaurus-prince-pdf --toc -u https://docs.getaurora.dev -o pdf/aurora.pdf


### PR DESCRIPTION
This fixes PDF generation with the prince package and docusaurus by downgrading the Node Version to 20. We should consider moving elsewhere since this package has seen no commits since 9 months ago and lacks modern Node.js treatment. 

This is a band-aid fix for now. 

There is also a change that builds the PDF for testing on a PR run and pushes it when committing to main. 