### PR TITLE
feat: document hard requirement for UEFI

### DIFF
--- a/docs/guides/system-requirements.md
+++ b/docs/guides/system-requirements.md
@@ -6,7 +6,7 @@ description: System requirements to comofortably use Aurora
 Using Aurora on your computer does not require any special sauce, but there are some system requirements you should be aware of. Other than the hard requirement of a 64-bit capable CPU (AMD/Intel) you should have at least the following system specifications on your Aurora Box:
 
 - Architecture: x86_64
-- Firmware: UEFI (CSM Support should be _disabled_ in the Firmware Setup if available)
+- Firmware: UEFI (CSM/Legacy Boot will not work)
 - Processor (CPU): 2GHz quad core or better
 - System Memory (RAM): 4GB
 - Graphics: A modern GPU that is Vulkan 1.3+ compliant


### PR DESCRIPTION
The move to new the new titanoboa in
https://github.com/get-aurora-dev/iso/pull/66 happened to break legacy bios for new installations. We have never cared about it.