### PR TITLE
chore: drop ventoy warning

### DIFF
--- a/docs/guides/install-guide.md
+++ b/docs/guides/install-guide.md
@@ -13,8 +13,6 @@ Flash the ISO with one of these tools:
 - [Rufus](https://rufus.ie/en/)
 - [Etcher](https://etcher.balena.io/)
 
-**Note**: Using Ventoy to boot the installation media is not supported as Ventoy's tricks to house multiple ISOs are incompatible with our ISOs.
-
 ## Booting Aurora's Installer
 
 **Note**: The current installer may be [changing](https://github.com/ublue-os/titanoboa) in the near future and this documentation may become outdated.


### PR DESCRIPTION
I just installed ventoy and put our newest ISO on it and it reached a desktop all fine. No grub2 mode or anything needed. This might be because of changes made in ventoy itself recently and us dropping bios from our ISO.

would need to be done for the website as well