### PR TITLE
chore: remove mentions about torrent in installation guide

### DIFF
--- a/docs/guides/install-guide.md
+++ b/docs/guides/install-guide.md
@@ -5,7 +5,7 @@ description: Installing Aurora to your desktop or laptop.
 
 ## Downloading & Flashing
 
-Download the ISO using the download picker from the [website](https://getaurora.dev) or download the [torrent](https://fosstorrents.com/distributions/aurora/).
+Download the ISO using the download picker from the [website](https://getaurora.dev).
 
 Flash the ISO with one of these tools:
 


### PR DESCRIPTION
remove the mentions of torrent availability. Fosstorrents has been broken for ages and also not updating etc and I just don't want to deal with them anymore