### PR TITLE
docs: add llmman to local AI guide and DX intro

### DIFF
--- a/docs/dx/aurora-dx-intro.md
+++ b/docs/dx/aurora-dx-intro.md
@@ -142,9 +142,9 @@ The JetBrains blog also has more information on JetBrains Dev Containers support
 
 For access to the full suite of [Cloud Native Computing Foundation](https://l.cncf.io) tools, use `ujust cncf` to browse and install from an extensive collection of 89 CNCF projects including graduated, incubating, and sandbox tools. This includes Argo, Cilium, Envoy, Flux, Istio, Linkerd, Prometheus, and many more.
 
-## Ramalama and other AI tools
+## Ramalama, llmman and other AI tools
 
-[Ramalama](https://github.com/containers/ramalama) can be installed via `ujust bbrew` and selecting the `ai` option for local management and serving of AI models. Check the [AI documentation](/guides/local-ai) for more information.
+[Ramalama](https://github.com/containers/ramalama) and [llmman](https://github.com/llmmanorg/llmman) can be installed via `ujust bbrew` and selecting the `ai` option for local management and serving of AI models. Check the [AI documentation](/guides/local-ai) for more information.
 
 ## Virtualization and Container Runtimes
 

--- a/docs/guides/local-ai.md
+++ b/docs/guides/local-ai.md
@@ -22,6 +22,7 @@ The following AI-focused command-line tools are available via homebrew, install 
 | [gemini-cli](https://formulae.brew.sh/formula/gemini-cli)           | Command-line interface for Google's Gemini API                   |
 | [kimi-cli](https://formulae.brew.sh/formula/kimi-cli)               | CLI for Moonshot AI's Kimi models                                |
 | [llm](https://formulae.brew.sh/formula/llm)                         | Access large language models from the command line               |
+| [llmman](https://github.com/llmmanorg/llmman)                       | Run any agent on any model, local or hosted                      |
 | [lm-studio](https://lmstudio.ai/)                                   | Desktop app for running local LLMs                               |
 | [mistral-vibe](https://formulae.brew.sh/formula/mistral-vibe)       | CLI for Mistral AI models                                        |
 | [mods](https://formulae.brew.sh/formula/mods)                       | AI on the command-line, from charm.sh                            |
@@ -64,6 +65,24 @@ quay.io/ramalama/rocm                      latest      8875feffdb87  5 days ago 
 
 ![Newelle](https://github.com/user-attachments/assets/af508f58-e696-4eba-956b-ad3dea19d315)
 )
+
+## llmman
+
+Install [llmman](https://github.com/llmmanorg/llmman) via `brew install llmmanorg/tap/llmman`. It runs coding agents (Claude Code, Codex, OpenCode and friends) against a model on your own machine or any hosted provider in one command. Models are pulled directly from Hugging Face or any OCI registry (Docker Hub, GHCR, quay) and stored as standard OCI image layouts; inference uses upstream `llama.cpp`, `vllm` or `mlx-lm`.
+
+```
+llmman launch claude --model qwen3.8   # an agent on a local model
+llmman run qwen3.8                     # just chat with a model
+llmman run hf.co/unsloth/Qwen3.5-0.8B-GGUF
+```
+
+You can also serve models locally, exposing an Ollama, OpenAI and Anthropic compatible endpoint:
+
+```
+llmman serve
+```
+
+Check the [llmman documentation](https://github.com/llmmanorg/llmman#readme) for hosted providers, multi-machine aggregation and registry-to-registry transfer.
 
 ## Alpaca
 


### PR DESCRIPTION
## What does this change?

- `docs/guides/local-ai.md`: adds llmman to the AI tools table and a new **llmman** section next to Ramalama (install via Homebrew, run models/agents, `llmman serve`).
- `docs/dx/aurora-dx-intro.md`: mentions llmman alongside Ramalama in the AI tools section.

## Why?

[llmman](https://github.com/llmmanorg/llmman) is being added to the shared `ai-tools.Brewfile` (projectbluefin/common) so `ujust bbrew` -> `ai` installs it, and `docker-model-plugin` is being dropped from the Aurora DX image. The docs should list it wherever Ramalama is listed.

The 2025 wrap-up blog post is left untouched as a historical record.